### PR TITLE
Llama quickstart deployable on Restack Cloud

### DIFF
--- a/examples/get-started/src/client.py
+++ b/examples/get-started/src/client.py
@@ -1,22 +1,4 @@
 import os
 from restack_ai import Restack
-from restack_ai.restack import CloudConnectionOptions
-from dotenv import load_dotenv  
 
-# Load environment variables from a .env file
-load_dotenv()
-
-# Without connection options (for local development)
 client = Restack()
-
-engine_id = os.getenv("RESTACK_ENGINE_ID")
-address = os.getenv("RESTACK_ENGINE_ADDRESS")
-api_key = os.getenv("RESTACK_ENGINE_API_KEY")
-
-connection_options = CloudConnectionOptions(
-    engine_id=engine_id,
-    address=address,
-    api_key=api_key
-)
-
-client = Restack(connection_options)

--- a/examples/get-started/src/client.py
+++ b/examples/get-started/src/client.py
@@ -1,3 +1,22 @@
+import os
 from restack_ai import Restack
+from restack_ai.restack import CloudConnectionOptions
+from dotenv import load_dotenv  
 
+# Load environment variables from a .env file
+load_dotenv()
+
+# Without connection options (for local development)
 client = Restack()
+
+engine_id = os.getenv("RESTACK_ENGINE_ID")
+address = os.getenv("RESTACK_ENGINE_ADDRESS")
+api_key = os.getenv("RESTACK_ENGINE_API_KEY")
+
+connection_options = CloudConnectionOptions(
+    engine_id=engine_id,
+    address=address,
+    api_key=api_key
+)
+
+client = Restack(connection_options)

--- a/examples/get-started/src/workflows/workflow.py
+++ b/examples/get-started/src/workflows/workflow.py
@@ -3,7 +3,7 @@ from restack_ai.workflow import workflow, import_functions, log
 with import_functions():
     from src.functions.function import welcome
 
-@workflow.defn(name="greeting")
+@workflow.defn()
 class GreetingWorkflow:
     @workflow.run
     async def run(self):

--- a/examples/get-started/src/workflows/workflow.py
+++ b/examples/get-started/src/workflows/workflow.py
@@ -3,7 +3,7 @@ from restack_ai.workflow import workflow, import_functions, log
 with import_functions():
     from src.functions.function import welcome
 
-@workflow.defn(name="GreetingWorkflow")
+@workflow.defn(name="greeting")
 class GreetingWorkflow:
     @workflow.run
     async def run(self):

--- a/examples/llama_quickstart/.env.example
+++ b/examples/llama_quickstart/.env.example
@@ -1,1 +1,5 @@
 TOGETHER_API_KEY=<your-together-api-key>
+RESTACK_SDK_TOKEN=<your-restack-sdk-token>
+RESTACK_ENGINE_ID=<your-restack-engine-id>
+RESTACK_ENGINE_ADDRESS=<your-restack-engine-address>
+RESTACK_ENGINE_API_KEY=<your-restack-engine-api-key>

--- a/examples/llama_quickstart/Dockerfile
+++ b/examples/llama_quickstart/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install poetry
+
+COPY pyproject.toml poetry.lock* ./
+
+COPY . .
+
+# Configure poetry to not create virtual environment
+RUN poetry config virtualenvs.create false
+
+# Install dependencies
+RUN poetry install --no-dev --no-interaction --no-ansi
+
+# Copy Nginx configuration
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx, FastAPI, and Streamlit using Poetry
+CMD service nginx start && \
+  poetry run uvicorn main:app --host 0.0.0.0 --port 8000 & \
+  poetry run streamlit run frontend.py --server.port=8501 --server.address=0.0.0.0  & \
+  poetry run services

--- a/examples/llama_quickstart/nginx.conf
+++ b/examples/llama_quickstart/nginx.conf
@@ -1,0 +1,29 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+
+        # Route to FastAPI on /api
+        location /api {
+            proxy_pass http://localhost:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Route to Streamlit on /
+        location / {
+            proxy_pass http://localhost:8501;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/examples/llama_quickstart/pyproject.toml
+++ b/examples/llama_quickstart/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "src"}]
 [tool.poetry.dependencies]
 python = "^3.12"
 pydantic = "^2.9.2"
-restack-ai = "^0.0.28"
+restack-ai = "^0.0.29"
 fastapi = "^0.115.4"
 llama-index = "^0.11.22"
 llama-index-llms-together = "^0.2.0"
@@ -19,6 +19,7 @@ uvicorn = "^0.32.0"
 python-dotenv = "0.19"
 streamlit = "^1.40.0"
 requests = "^2.32.3"
+restack-sdk-cloud = "^1.0.11"
 
 [build-system]
 requires = ["poetry-core"]

--- a/examples/llama_quickstart/restack_up.py
+++ b/examples/llama_quickstart/restack_up.py
@@ -1,0 +1,44 @@
+import os
+from restack_sdk_cloud import RestackCloud
+from dotenv import load_dotenv  
+load_dotenv()
+
+async def main():
+    # Initialize the RestackCloud client with the SDK token from environment variables
+    restack_cloud_client = RestackCloud(os.getenv('RESTACK_SDK_TOKEN'))
+
+    # Define the application configuration
+    app = {
+        'name': 'llama_quickstart',
+        'dockerFilePath': 'Dockerfile',
+        'dockerBuildContext': '.',
+        'environmentVariables': [
+            {
+                'name': 'RESTACK_ENGINE_ID',
+                'value': os.getenv('RESTACK_ENGINE_ID'),
+            },
+            {
+                'name': 'RESTACK_ENGINE_ADDRESS',
+                'value': os.getenv('RESTACK_ENGINE_ADDRESS'),
+            },
+            {
+                'name': 'RESTACK_ENGINE_API_KEY',
+                'value': os.getenv('RESTACK_ENGINE_API_KEY'),
+            },
+        ],
+    }
+
+    # Configure the stack with the applications
+    await restack_cloud_client.stack({
+        'name': 'development environment python',
+        'previewEnabled': False,
+        'applications': [app],
+    })
+
+    # Deploy the stack
+    await restack_cloud_client.up()
+
+# Run the main function
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/examples/llama_quickstart/src/app.py
+++ b/examples/llama_quickstart/src/app.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from src.client import client
 import time
-from restack_ai import Restack
 import uvicorn
+
 
 # Define request model
 class QueryRequest(BaseModel):
@@ -28,11 +29,11 @@ async def home():
 @app.post("/api/schedule")
 async def schedule_workflow(request: QueryRequest):
     try:
-        client = Restack()
+
         workflow_id = f"{int(time.time() * 1000)}-llm_complete_workflow"
         
         runId = await client.schedule_workflow(
-            workflow_name="hn_workflow",
+            workflow_name="HnWorkflow",
             workflow_id=workflow_id,
             input={"query": request.query, "count": request.count}
         )

--- a/examples/llama_quickstart/src/client.py
+++ b/examples/llama_quickstart/src/client.py
@@ -1,3 +1,20 @@
+import os
 from restack_ai import Restack
+from restack_ai.restack import CloudConnectionOptions
+from dotenv import load_dotenv  
 
-client = Restack()
+# Load environment variables from a .env file
+load_dotenv()
+
+
+engine_id = os.getenv("RESTACK_ENGINE_ID")
+address = os.getenv("RESTACK_ENGINE_ADDRESS")
+api_key = os.getenv("RESTACK_ENGINE_API_KEY")
+
+connection_options = CloudConnectionOptions(
+    engine_id=engine_id,
+    address=address,
+    api_key=api_key
+)
+
+client = Restack(connection_options)

--- a/examples/llama_quickstart/src/functions/crawl/website.py
+++ b/examples/llama_quickstart/src/functions/crawl/website.py
@@ -2,7 +2,7 @@ from restack_ai.function import function, log
 import requests
 from bs4 import BeautifulSoup
 
-@function.defn(name="crawl_website")
+@function.defn()
 async def crawl_website(url):
     try:
         # Send a GET request to the URL

--- a/examples/llama_quickstart/src/functions/hn/search.py
+++ b/examples/llama_quickstart/src/functions/hn/search.py
@@ -2,7 +2,7 @@ import requests
 from restack_ai.function import function, log
 from src.functions.hn.schema import HnSearchInput
 
-@function.defn(name="hn_search")
+@function.defn()
 async def hn_search(input: HnSearchInput):
     try:
         # Fetch the latest stories IDs

--- a/examples/llama_quickstart/src/functions/llm/chat.py
+++ b/examples/llama_quickstart/src/functions/llm/chat.py
@@ -11,7 +11,7 @@ class FunctionInputParams(BaseModel):
     system_prompt: str
     user_prompt: str
 
-@function.defn(name="llm_chat")
+@function.defn()
 async def llm_chat(input: FunctionInputParams):
     try:
         api_key = os.getenv("TOGETHER_API_KEY")

--- a/examples/llama_quickstart/src/services.py
+++ b/examples/llama_quickstart/src/services.py
@@ -2,14 +2,14 @@ import asyncio
 from src.client import client
 from src.functions.llm.chat import llm_chat
 from src.functions.hn.search import hn_search
-from src.workflows.workflow import hn_workflow
+from src.workflows.workflow import HnWorkflow
 from src.functions.crawl.website import crawl_website
 from restack_ai.restack import ServiceOptions
 
 async def main():
     await asyncio.gather(
         client.start_service(
-            workflows=[hn_workflow],
+            workflows=[HnWorkflow],
             functions=[hn_search, crawl_website]
         ),
         client.start_service(

--- a/examples/llama_quickstart/src/workflows/workflow.py
+++ b/examples/llama_quickstart/src/workflows/workflow.py
@@ -6,10 +6,9 @@ with import_functions():
     from src.functions.hn.schema import HnSearchInput
     from src.functions.crawl.website import crawl_website
     from src.functions.llm.chat import llm_chat, FunctionInputParams
-    
 
-@workflow.defn(name="hn_workflow")
-class hn_workflow:
+@workflow.defn()
+class HnWorkflow:
     @workflow.run
     async def run(self, input: dict):
 


### PR DESCRIPTION

- bump to restack_ai 0.0.29 fixing cloud engine connection
- add dockerfile and nginx to run streamlit,fastapi and services all in one container
- add restack_up for CI/CD 