### PR TITLE
Update openbabylon url in .env.example

### DIFF
--- a/defense_quickstart_audio_transcription_translation/.env.example
+++ b/defense_quickstart_audio_transcription_translation/.env.example
@@ -1,5 +1,5 @@
 GROQ_API_KEY=<your-groq-api-key>
-OPENBABYLON_API_URL=http://64.139.222.109:80
+OPENBABYLON_API_URL=http://64.139.222.109:80/v1
 # (Optional) to deploy on Restack Cloud
 
 # RESTACK_ENGINE_ID=<your-restack-engine-id>

--- a/defense_quickstart_audio_transcription_translation/README.md
+++ b/defense_quickstart_audio_transcription_translation/README.md
@@ -17,7 +17,6 @@ Find audio samples at https://drive.google.com/drive/folders/1mbchTGfmhq2sc7sQEM
 During the hackathon, OpenBabylon provided a public url:
 
 OPENBABYLON_API_URL=http://64.139.222.109:80/v1
-No api key is needed, although a dummy api_key="openbabylon" is necessary for openai sdk.
 
 ## Prerequisites
 
@@ -73,7 +72,6 @@ No api key is needed, although a dummy api_key="openbabylon" is necessary for op
    # Edit .env and add your:
    # OPENBABYLON_API_URL
    # GROQ_API_KEY
-   # OPENAI_API_KEY - Set this to a random string as OpenBabylon uses OpenAI API
    ```
 
 6. Run the services:


### PR DESCRIPTION
- updates openbabylon url in the .env.example
- updates the readme to remove the part of openai dummy api key as we've changed to have placeholder in place where we call the client