### PR TITLE
Endpoints with openai greet example

### DIFF
--- a/openai_greet/pyproject.toml
+++ b/openai_greet/pyproject.toml
@@ -12,7 +12,7 @@ packages = [{include = "src"}]
 python = ">=3.10,<4.0"
 openai = "^1.57.2"
 python-dotenv = "1.0.1"
-restack-ai = "^0.0.48"
+restack-ai = "^0.0.49"
 
 [build-system]
 requires = ["poetry-core"]

--- a/openai_greet/src/services.py
+++ b/openai_greet/src/services.py
@@ -2,11 +2,16 @@ import asyncio
 from src.functions.function import openai_greet
 from src.client import client
 from src.workflows.openai_greet import OpenaiGreetWorkflow
+from restack_ai.restack import ServiceOptions
+
 async def main():
 
     await client.start_service(
         workflows= [OpenaiGreetWorkflow],
         functions= [openai_greet],
+        options=ServiceOptions(
+            endpoints= True
+        ),
     )
 
 def run_services():


### PR DESCRIPTION

- Use release candidate version:

docker run -d --pull always --name restack-rc -p 5233:5233 -p 6233:6233 -p 7233:7233 ghcr.io/restackio/restack:rc

- Bump restack to 0.0.49

- Add endpoints=true to ServiceOptions when doing start_service

- Ability to trigger workflows directly from UI or generated API endpoint

To add a Bearer token run

docker run -d --pull always --name restack-rc -p 5233:5233 -p 6233:6233 -p 7233:7233 -e BEARER_TOKEN=your_token ghcr.io/restackio/restack:rc

and then add "your_token" in Authenticate dialog
![Screenshot 2024-12-14 at 12 29 14](https://github.com/user-attachments/assets/3e0cac9e-0082-43f1-9928-2bceb6b1a604)

