### PR TITLE
[production_demo] Fix Client for cloud

### DIFF
--- a/production_demo/.env.Example
+++ b/production_demo/.env.Example
@@ -3,4 +3,4 @@
 # RESTACK_ENGINE_ID=<your-engine-id>
 # RESTACK_ENGINE_API_KEY=<your-engine-api-key>
 # RESTACK_ENGINE_ADDRESS=<your-engine-address>
-# RESTACK_CLOUD_TOKEN=<your-cloud-token>
+# RESTACK_ENGINE_API_ADDRESS=<your-engine-api-address>

--- a/production_demo/src/client.py
+++ b/production_demo/src/client.py
@@ -10,10 +10,12 @@ load_dotenv()
 engine_id = os.getenv("RESTACK_ENGINE_ID")
 address = os.getenv("RESTACK_ENGINE_ADDRESS")
 api_key = os.getenv("RESTACK_ENGINE_API_KEY")
+api_address = os.getenv("RESTACK_ENGINE_API_ADDRESS")
 
 connection_options = CloudConnectionOptions(
     engine_id=engine_id,
     address=address,
-    api_key=api_key
+    api_key=api_key,
+    api_address=api_address
 )
 client = Restack(connection_options)


### PR DESCRIPTION
1. Add missing env variable in client 'RESTACK_ENGINE_API_ADDRESS'