### PR TITLE
fix production services

### DIFF
--- a/production_demo/src/services.py
+++ b/production_demo/src/services.py
@@ -46,3 +46,5 @@ def watch_services():
     webbrowser.open("http://localhost:5233")
     run_process(watch_path, recursive=True, target=run_services)
 
+if __name__ == "__main__":
+    run_services()


### PR DESCRIPTION
Container was stuck after initializing client and did not start services because of missing idiom at the end.  ensures that run_services() is only called when services.py is run directly, and not when another module imports it.