### PR TITLE
Speed up build with external image

### DIFF
--- a/pdf_ocr/Dockerfile
+++ b/pdf_ocr/Dockerfile
@@ -2,12 +2,6 @@ FROM ghcr.io/restackio/uv-torch:main
 
 WORKDIR /app
 
-# # Combine apt installs to reduce layers
-# RUN apt-get update && apt-get install -y --no-install-recommends\
-#   libglib2.0-0 \
-#   libgl1-mesa-glx \
-#   && apt-get clean && rm -rf /var/lib/apt/lists/*
-
 COPY pyproject.toml requirements.txt ./
 
 COPY . .

--- a/pdf_ocr/Dockerfile
+++ b/pdf_ocr/Dockerfile
@@ -1,12 +1,12 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/restackio/uv-torch:main
 
 WORKDIR /app
 
-# Combine apt installs to reduce layers
-RUN apt-get update && apt-get install -y --no-install-recommends\
-  libglib2.0-0 \
-  libgl1-mesa-glx \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+# # Combine apt installs to reduce layers
+# RUN apt-get update && apt-get install -y --no-install-recommends\
+#   libglib2.0-0 \
+#   libgl1-mesa-glx \
+#   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml requirements.txt ./
 


### PR DESCRIPTION

- Build the pytorch and uv in separate image https://github.com/restackio/uv-torch
- Pull common image to speed up build on Restack Cloud 