### PR TITLE
Bump restack_ai versions to use typing-extensions instead

### DIFF
--- a/agent_apis/pyproject.toml
+++ b/agent_apis/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "python-dotenv==1.0.1",
     "openai>=1.61.0",
     "aiohttp>=3.11.12",
-    "restack-ai>=0.0.68",
+    "restack-ai>=0.0.69",
 ]
 
 [project.scripts]

--- a/agent_chat/pyproject.toml
+++ b/agent_chat/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "watchfiles>=1.0.4",
     "python-dotenv==1.0.1",
     "openai>=1.61.0",
-    "restack-ai>=0.0.68",
+    "restack-ai>=0.0.69",
 ]
 
 [project.scripts]

--- a/agent_rag/pyproject.toml
+++ b/agent_rag/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "watchfiles>=1.0.4",
     "requests==2.32.3",
     "python-dotenv==1.0.1",
-    "restack-ai>=0.0.68",
+    "restack-ai>=0.0.69",
 ]
 
 [project.scripts]

--- a/agent_todo/pyproject.toml
+++ b/agent_todo/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "watchfiles>=1.0.4",
     "python-dotenv==1.0.1",
     "openai>=1.61.0",
-    "restack-ai>=0.0.68",
+    "restack-ai>=0.0.69",
 ]
 
 [project.scripts]

--- a/agent_tool/pyproject.toml
+++ b/agent_tool/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "watchfiles>=1.0.4",
     "requests==2.32.3",
     "python-dotenv==1.0.1",
-    "restack-ai>=0.0.68",
+    "restack-ai>=0.0.69",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Update restack_ai version in agent examples to align with the latest changes, including the use of NotRequired from typing-extensions instead of typing