### PR TITLE
Fix agent_chat example appending ChatCompletion instead of Message

### DIFF
--- a/agent_chat/src/agents/agent.py
+++ b/agent_chat/src/agents/agent.py
@@ -25,11 +25,15 @@ class AgentChat:
     async def message(self, message: MessageEvent) -> list[Message]:
         log.info(f"Received message: {message.content}")
         self.messages.append({"role": "user", "content": message.content})
-        assistant_message = await agent.step(
+        assistant_message_raw = await agent.step(
             function=llm_chat,
             function_input=LlmChatInput(messages=self.messages),
             start_to_close_timeout=timedelta(seconds=120),
         )
+        assistant_message = {
+            "role": assistant_message_raw.choices[0].message.role,
+            "content": assistant_message_raw.choices[0].message.content,
+        }
         self.messages.append(assistant_message)
         return self.messages
 

--- a/agent_chat/src/agents/agent.py
+++ b/agent_chat/src/agents/agent.py
@@ -25,15 +25,11 @@ class AgentChat:
     async def message(self, message: MessageEvent) -> list[Message]:
         log.info(f"Received message: {message.content}")
         self.messages.append({"role": "user", "content": message.content})
-        assistant_message_raw = await agent.step(
+        assistant_message = await agent.step(
             function=llm_chat,
             function_input=LlmChatInput(messages=self.messages),
             start_to_close_timeout=timedelta(seconds=120),
         )
-        assistant_message = {
-            "role": assistant_message_raw.choices[0].message.role,
-            "content": assistant_message_raw.choices[0].message.content,
-        }
         self.messages.append(assistant_message)
         return self.messages
 

--- a/agent_chat/src/functions/llm_chat.py
+++ b/agent_chat/src/functions/llm_chat.py
@@ -27,7 +27,7 @@ def raise_exception(message: str) -> None:
 
 
 @function.defn()
-async def llm_chat(agent_input: LlmChatInput) -> ChatCompletion:
+async def llm_chat(agent_input: LlmChatInput) -> dict[str, str]:
     try:
         log.info("llm_chat function started", agent_input=agent_input)
 
@@ -44,7 +44,7 @@ async def llm_chat(agent_input: LlmChatInput) -> ChatCompletion:
                 {"role": "system", "content": agent_input.system_content}
             )
 
-        response = client.chat.completions.create(
+        assistant_raw_response = client.chat.completions.create(
             model=agent_input.model or "gpt-4o-mini",
             messages=agent_input.messages,
         )
@@ -52,6 +52,13 @@ async def llm_chat(agent_input: LlmChatInput) -> ChatCompletion:
         log.error("llm_chat function failed", error=e)
         raise
     else:
-        log.info("llm_chat function completed", response=response)
+        log.info("llm_chat function completed", assistant_raw_response=assistant_raw_response)
 
-        return response
+        assistant_response = {
+            "role": assistant_raw_response.choices[0].message.role,
+            "content": assistant_raw_response.choices[0].message.content,
+        }
+
+        log.info("assistant_response", assistant_response=assistant_response)
+
+        return assistant_response

--- a/agent_chat/src/functions/llm_chat.py
+++ b/agent_chat/src/functions/llm_chat.py
@@ -51,7 +51,9 @@ async def llm_chat(agent_input: LlmChatInput) -> dict[str, str]:
         log.error("llm_chat function failed", error=e)
         raise
     else:
-        log.info("llm_chat function completed", assistant_raw_response=assistant_raw_response)
+        log.info(
+            "llm_chat function completed", assistant_raw_response=assistant_raw_response
+        )
 
         assistant_response = {
             "role": assistant_raw_response.choices[0].message.role,

--- a/agent_chat/src/functions/llm_chat.py
+++ b/agent_chat/src/functions/llm_chat.py
@@ -3,7 +3,6 @@ from typing import Literal
 
 from dotenv import load_dotenv
 from openai import OpenAI
-from openai.types.chat.chat_completion import ChatCompletion
 from pydantic import BaseModel
 from restack_ai.function import FunctionFailure, function, log
 


### PR DESCRIPTION
Before: `agent_chat` successfully responded to the first event, but all subsequent messages caused a Pydantic validation error. This happened because the response appended to `self.messages` after the first run did not satisfy `LlmChatInput`

Now: Extract the necessary properties from the `llm_chat` response and append the correctly formatted assistant_message

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/d78a4cf7-da95-4340-89a4-44a33e0e433b" />
