### PR TITLE
Fix Agent_todo example

### DIFF
--- a/agent_todo/src/agents/agent_todo.py
+++ b/agent_todo/src/agents/agent_todo.py
@@ -120,7 +120,7 @@ class AgentTodo:
                             result = await agent.child_execute(
                                 workflow=TodoExecute,
                                 workflow_id=tool_call.id,
-                                input=args,
+                                workflow_input=args,
                             )
                             self.messages.append(
                                 Message(

--- a/agent_todo/src/workflows/todo_execute.py
+++ b/agent_todo/src/workflows/todo_execute.py
@@ -23,25 +23,28 @@ class TodoExecuteResponse(BaseModel):
 @workflow.defn()
 class TodoExecute:
     @workflow.run
-    async def run(self, params: TodoExecuteParams) -> TodoExecuteResponse:
+    async def run(self, workflow_input: TodoExecuteParams) -> TodoExecuteResponse:
         log.info("TodoExecuteWorkflow started")
         random = await workflow.step(
-            get_random,
-            function_input=RandomParams(todo_title=params.todo_title),
+            function=get_random,
+            function_input=RandomParams(todo_title=workflow_input.todo_title),
             start_to_close_timeout=timedelta(seconds=120),
         )
 
         await workflow.sleep(2)
 
         result = await workflow.step(
-            get_result,
-            function_input=ResultParams(todo_title=params.todo_title, todo_id=params.todo_id),
+            function=get_result,
+            function_input=ResultParams(
+                todo_title=workflow_input.todo_title,
+                todo_id=workflow_input.todo_id,
+            ),
             start_to_close_timeout=timedelta(seconds=120),
         )
 
         todo_details = TodoExecuteResponse(
-            todo_id=params.todo_id,
-            todo_title=params.todo_title,
+            todo_id=workflow_input.todo_id,
+            todo_title=workflow_input.todo_title,
             details=random,
             status=result.status,
         )


### PR DESCRIPTION
Before: `agent_todo` passed `input=args` when calling a child workflow, while `todo_execute` expected `params`, causing a mismatch

Now: Both workflows consistently use `workflow_input` for proper parameter passing