### PR TITLE
Update examples to use gpt-4.1-mini

### DIFF
--- a/agent_telephony/twilio_livekit/agent_twilio/src/functions/llm_logic.py
+++ b/agent_telephony/twilio_livekit/agent_twilio/src/functions/llm_logic.py
@@ -36,7 +36,7 @@ async def llm_logic(
             voice_mail_detection = ""
 
         response = client.beta.chat.completions.parse(
-            model="gpt-4o",
+            model="gpt-4.1-mini",
             messages=[
                 {
                     "role": "system",


### PR DESCRIPTION
Updates the examples to use `gpt-4.1-mini` instead of `gpt-4o`