### PR TITLE
replaced restack_api_key for openai_api_key in env.vars and functions

### DIFF
--- a/agent_rag/.env.Example
+++ b/agent_rag/.env.Example
@@ -1,2 +1,2 @@
 # Restack  API key for the llm call 
-RESTACK_API_KEY=<your_restack_api_key>
+OPENAI_API_KEY=<your_openai_api_key>

--- a/agent_todo/src/functions/llm_chat.py
+++ b/agent_todo/src/functions/llm_chat.py
@@ -40,8 +40,8 @@ async def llm_chat(function_input: LlmChatInput) -> ChatCompletion:
     try:
         log.info("llm_chat function started", function_input=function_input)
 
-        if os.environ.get("RESTACK_API_KEY") is None:
-            raise_exception("RESTACK_API_KEY is not set")
+        if os.environ.get("OPENAI_API_KEY") is None:
+            raise_exception("OPENAI_API_KEY is not set")
 
         client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 

--- a/agent_tool/.env.Example
+++ b/agent_tool/.env.Example
@@ -1,2 +1,2 @@
 # Restack  API key for the llm call 
-RESTACK_API_KEY=<your_restack_api_key>
+OPENAI_API_KEY=<your_openai_api_key>


### PR DESCRIPTION
<img width="807" alt="Screenshot 2025-05-18 at 08 36 45" src="https://github.com/user-attachments/assets/576cbea8-ddb1-4b32-877c-0ade7b165b27" />

- Replaced mentions to restack_key for openai